### PR TITLE
Cache management by "workspace"

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,6 +7,7 @@ extensions = [
     "oembedpy.ext.sphinx",
     "rst_package_refs.sphinx",
     "sphinx.ext.autodoc",
+    "sphinx_toolbox.confval",
 ]
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,6 +5,7 @@ author = "Kazuya Takei"
 
 extensions = [
     "oembedpy.ext.sphinx",
+    "rst_package_refs.sphinx",
     "sphinx.ext.autodoc",
 ]
 templates_path = ["_templates"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ Included features
    :caption: Contents:
 
    commandline
+   workspace
    integrations/sphinx
    api
    changelogs

--- a/docs/integrations/sphinx.rst
+++ b/docs/integrations/sphinx.rst
@@ -28,6 +28,21 @@ Write ``oembed`` directive into your document.
 
 When it build, embed ``iframe`` content into your HTML.
 
+Configuration
+-------------
+
+.. confval:: oembed_use_workspace
+
+   :Type: ``bool``
+   :Default: ``False``
+
+   Switch to toggle using simple client and workspace.
+
+   If it is set ``True```, extension uses ``Workspace`` object as client.
+
+   .. note:: See :doc:`../workspace` for more information.
+
+
 Spec of directive
 -----------------
 

--- a/docs/workspace.rst
+++ b/docs/workspace.rst
@@ -1,0 +1,7 @@
+=========
+Workspace
+=========
+
+oEmbedPy uses user local directory to management configuration and cache.
+
+.. note:: Refer to :pypi:`platformdirs`

--- a/docs/workspace.rst
+++ b/docs/workspace.rst
@@ -4,4 +4,53 @@ Workspace
 
 oEmbedPy uses user local directory to management configuration and cache.
 
-.. note:: Refer to :pypi:`platformdirs`
+About workspace
+===============
+
+Workspace is construction to manage local state of oEmbed by ``oEmbed.py``.
+You can empower performance of oEmbed.py to use workspace instead of simple CLI.
+
+Behaviors of workspace
+======================
+
+Cache of provider list
+----------------------
+
+oEmbed.py fetch https://oembed.com/providers.json to collect providers' URL.
+With workspace, cache fetched json file in 1 day to reduce requests.
+
+Cache of responses from providers
+---------------------------------
+
+oEmbed content may have to response with ``cache_age`` parameter.
+With workspace, CLI save content with ``cache_age`` into cache and reuse it until expired.
+
+Usage for workspace
+===================
+
+In CLI command
+--------------
+
+Add ``-w/--workspace`` option with CLI.
+
+In Sphinx extension
+-------------------
+
+Set :confval:`oembed_use_workspace` into your ``conf.py``.
+
+Remove caches
+-------------
+
+oEmbedPy uses :pypi:`platformdirs` to manage locale of caches.
+If you want to remove caches' files, refer to ``user_data_path``.
+
+example:
+
+.. list-table::
+
+   - * macOS
+     * ``/Users/{USERNAME}/Library/Application Support/oembedpy``
+   - * Windows
+     * ``C:\Users\{USERNAME}\AppData\Local\Acme\oembedpy``
+   - * Linux
+     * ``/home/{USERNAME}/.local/share/oembedpy``

--- a/oembedpy/application.py
+++ b/oembedpy/application.py
@@ -1,9 +1,13 @@
 """Core endpoint."""
 
+import json
 import logging
+import time
 from typing import Optional
 
 import httpx
+
+from platformdirs import PlatformDirs
 
 from oembedpy import consumer, discovery
 from oembedpy.provider import ProviderRegistry
@@ -15,11 +19,14 @@ logger = logging.getLogger(__name__)
 class Oembed:
     """Application of oEmbed."""
 
-    registry: ProviderRegistry
+    _registry: ProviderRegistry
 
     def __init__(self):  # noqa: D107
+        pass
+
+    def init(self):
         resp = httpx.get("https://oembed.com/providers.json")
-        self.registry = ProviderRegistry.from_dict(resp.json())
+        self._registry = ProviderRegistry.from_dict(resp.json())
 
     def fetch(
         self,
@@ -41,3 +48,34 @@ class Oembed:
             params.max_height = max_height
         content = consumer.fetch_content(api_url, params)
         return content
+
+
+class Workspace(Oembed):
+    """oEmbed client with workspace."""
+
+    def __init__(self):
+        self._dirs = PlatformDirs("oembedpy")
+
+    @property
+    def cache_dir(self):
+        return self._dirs.user_data_path
+
+    def init(self):
+        providers_json = self.cache_dir / "providers.json"
+        use_cache = providers_json.exists()
+        if use_cache:
+            now_ts = time.mktime(time.localtime())
+            file_ts = providers_json.stat().st_mtime
+            # TODO: expired time is temporary value, refer settings or default after.
+            use_cache = file_ts + (3600 * 24) > now_ts
+
+        providers_data: dict
+        if use_cache:
+            providers_data = json.loads(providers_json.read_text())
+        else:
+            providers_json.parent.mkdir(parents=True, exist_ok=True)
+            resp = httpx.get("https://oembed.com/providers.json")
+            providers_data = resp.json()
+            providers_json.write_text(resp.text)
+
+        self._registry = ProviderRegistry.from_dict(providers_data)

--- a/oembedpy/application.py
+++ b/oembedpy/application.py
@@ -36,7 +36,7 @@ class Oembed:
     ) -> Content:
         """Find endpoint from registry and content."""
         try:
-            api_url, params = discovery.find_from_registry(url)
+            api_url, params = discovery.find_from_registry(url, self._registry)
         except ValueError:  # TODO: Split error case?
             logger.warning("It is not found from registry. Try from content.")
             api_url, params = discovery.find_from_content(url)

--- a/oembedpy/cli.py
+++ b/oembedpy/cli.py
@@ -23,6 +23,9 @@ OUTPUT_FORMAT = Literal["text", "json"]
     "--version", is_flag=True, default=False, help="Show version information and exit."
 )
 @click.option(
+    "-w", "--workspace", is_flag=True, default=False, help="Use caching workspace."
+)
+@click.option(
     "--format",
     type=click.Choice(["text", "json"]),
     default="text",
@@ -35,6 +38,7 @@ OUTPUT_FORMAT = Literal["text", "json"]
 def cli(
     ctx: click.Context,
     version: bool,
+    workspace: bool,
     url: str,
     format: OUTPUT_FORMAT,
     max_width: Optional[int] = None,
@@ -47,7 +51,8 @@ def cli(
 
     # Fetch content to find meta tags.
     logger.debug(f"Target Content URL is {url}")
-    oembed = application.Oembed()
+    oembed = application.Workspace() if workspace else application.Oembed()
+    oembed.init()
     try:
         content = oembed.fetch(url, max_width, max_height)
     except Exception as err:

--- a/oembedpy/consumer.py
+++ b/oembedpy/consumer.py
@@ -21,6 +21,9 @@ class RequestParameters:
     max_width: Optional[int] = None
     max_height: Optional[int] = None
 
+    def __hash__(self):
+        return hash((self.url, self.format, self.max_width, self.max_height))
+
     def to_dict(self) -> Dict[str, str]:
         """Make dict object from properties."""
         data = {"url": self.url}

--- a/oembedpy/discovery.py
+++ b/oembedpy/discovery.py
@@ -5,7 +5,7 @@ This provides features to find oEmbed provider of contents.
 
 import logging
 import urllib.parse
-from typing import Optional, Tuple
+from typing import Tuple
 
 import httpx
 from bs4 import BeautifulSoup
@@ -50,13 +50,9 @@ def find_from_content(url: str) -> Tuple[str, RequestParameters]:
 
 
 def find_from_registry(
-    url: str, registry: Optional[ProviderRegistry] = None
+    url: str, registry: ProviderRegistry
 ) -> Tuple[str, RequestParameters]:
     """Find endpoint matched for content from registry."""
-    if registry is None:
-        resp = httpx.get("https://oembed.com/providers.json")
-        registry = ProviderRegistry.from_dict(resp.json())
-
     for provider in registry.providers:
         api_url = provider.find_endpoint(url)
         if api_url:

--- a/oembedpy/ext/sphinx.py
+++ b/oembedpy/ext/sphinx.py
@@ -63,6 +63,7 @@ def setup(app: Sphinx):  # noqa: D103
         html=(visit_oembed_node, depart_oembed_node),
     )
     _oembed = Oembed()
+    _oembed.init()
     return {
         "version": __version__,
         "parallel_read_safe": True,

--- a/oembedpy/types.py
+++ b/oembedpy/types.py
@@ -6,7 +6,7 @@ Please see https://oembed.com/
 
 from dataclasses import asdict, dataclass
 from inspect import signature
-from typing import Any, Dict, Optional, Type, TypeVar, Union
+from typing import Any, Dict, NamedTuple, Optional, Type, TypeVar, Union
 
 T = TypeVar("T", bound="_Required")
 
@@ -103,3 +103,8 @@ class Rich(_Optionals, _Rich, _Required):
 
 Content = Union[Photo, Video, Link, Rich]
 """Collection of oEmbed content types."""
+
+
+class CachedContent(NamedTuple):
+    expired: float
+    content: Content

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ test = [
   "pytest==7.*",
   "pytest-cov==4.*",
   "pytest-httpx==0.21.*",
+  "pytest-mock==3.14.*",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
   "beautifulsoup4",
   "httpx",
   "lxml",
+  "platformdirs",
 ]
 dynamic = ["version", "description"]
 
@@ -35,6 +36,7 @@ cli = ["Click>=8"]
 doc = [
   "furo",
   "Sphinx",
+  "rst-package-refs",
 ]
 sphinx = [
   "sphinx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ cli = ["Click>=8"]
 doc = [
   "furo",
   "Sphinx",
+  "sphinx-toolbox",
   "rst-package-refs",
 ]
 sphinx = [

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,4 +1,5 @@
 # flake8: noqa
+import pickle
 import subprocess
 from pathlib import Path
 
@@ -70,3 +71,24 @@ class TestForWorkspace:
         other_workspace = application.Workspace()
         other_workspace.init()
         assert spy.call_count == 2
+
+    def test_initialized_response_cache(
+        self, mocked_workspace: application.Workspace, tmp_path
+    ):
+        mocked_workspace.init()
+        assert (tmp_path / "providers.json").exists()
+        mocked_workspace.__del__()
+        assert (tmp_path / "db.pickle").exists()
+
+    def test_initialized_response_cache(
+        self, mocked_workspace: application.Workspace, tmp_path
+    ):
+        mocked_workspace.init()
+        mocked_workspace.fetch(
+            "https://bsky.app/profile/attakei.dev/post/3kr76heazfp2i"
+        )
+        mocked_workspace.__del__()
+        db_path = tmp_path / "db.pickle"
+        assert db_path.exists()
+        db = pickle.loads(db_path.read_bytes())
+        assert len(db) == 1

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,0 +1,72 @@
+# flake8: noqa
+import subprocess
+from pathlib import Path
+
+import httpx
+import pytest
+from platformdirs.api import PlatformDirsABC
+from pytest_mock import MockerFixture
+
+
+from oembedpy import application
+
+
+@pytest.fixture
+def mocked_workspace(monkeypatch, tmp_path):
+    def _append_app_name_and_version(*arg, **kwargs):
+        return tmp_path
+
+    monkeypatch.setattr(
+        PlatformDirsABC,
+        "_append_app_name_and_version",
+        _append_app_name_and_version,
+    )
+    ws = application.Workspace()
+    return ws
+
+
+@pytest.mark.skipif("sys.platform != 'linux'")
+def test_workspace():
+    ws = application.Workspace()
+    assert ws.cache_dir == Path.home() / ".local" / "share/oembedpy"
+
+
+@pytest.mark.skipif("sys.platform != 'linux'")
+class TestForWorkspace:
+    def test_properties(self, mocked_workspace: application.Workspace, tmp_path):
+        assert mocked_workspace.cache_dir == tmp_path
+
+    def test_cache_providers_json(
+        self, mocked_workspace: application.Workspace, tmp_path
+    ):
+        mocked_workspace.init()
+        assert (tmp_path / "providers.json").exists()
+        assert mocked_workspace._registry is not None
+
+    def test_fetch_using_cached_providers_json(
+        self, mocked_workspace: application.Workspace, mocker: MockerFixture, tmp_path
+    ):
+        spy = mocker.spy(httpx, "get")
+        mocked_workspace.init()
+        assert spy.call_count == 1
+        other_workspace = application.Workspace()
+        other_workspace.init()
+        assert spy.call_count == 1
+
+    def test_purge_cached_providers_json(
+        self, mocked_workspace: application.Workspace, mocker: MockerFixture, tmp_path
+    ):
+        spy = mocker.spy(httpx, "get")
+        mocked_workspace.init()
+        assert spy.call_count == 1
+        subprocess.run(
+            [
+                "touch",
+                "-t",
+                "200001010000",
+                (mocked_workspace.cache_dir / "providers.json"),
+            ]
+        )
+        other_workspace = application.Workspace()
+        other_workspace.init()
+        assert spy.call_count == 2


### PR DESCRIPTION
Works

* Define workspace
* Keep `providers.json` and responsed contents as cache

Not worked

* Configuration settings for users

## Refs

#2, #3